### PR TITLE
Generate and preload NRG Common Library annotation metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    dependencies {
+        // Add the Reflections library and dependencies to the classpath so we
+        // can generate its metadata during the build.
+        classpath 'org.reflections:reflections:0.10.2'
+        classpath 'org.dom4j:dom4j:2.1.3'
+    }
+}
+
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2024.2.1"
@@ -11,7 +20,7 @@ java {
 def ROBOT_MAIN_CLASS = "frc.robot.Main"
 
 repositories {
-    maven {
+        maven {
         url = uri("https://maven.pkg.github.com/NRG948/nrgcommon")
         credentials {
             username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
@@ -77,7 +86,7 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    implementation 'com.nrg948:nrgcommon:2024.1.1-SNAPSHOT'
+    implementation 'com.nrg948:nrgcommon:2024.1.2-SNAPSHOT'
 }
 
 test {
@@ -108,3 +117,35 @@ wpi.java.configureTestTasks(test)
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }
+
+// Generates metadata consumed by the NRG Common Library to find annotations at runtime.
+task generateReflectionsMetadata {
+    dependsOn compileJava
+
+    doLast {
+        // Create a class loader for the main project files.
+        Set<File> projectDirs = project.sourceSets.main.output.classesDirs.files
+        URL[] projectUrls = projectDirs.collect { it.toURI().toURL() }.toArray(new URL[0])
+        ClassLoader projectLoader = new URLClassLoader(projectUrls, (java.lang.ClassLoader)null)
+
+        // Create a class loader for the project runtime dependencies.
+        Set<File> classpathFiles = project.configurations.runtimeClasspath.files
+        URL[] classpathUrls = classpathFiles.collect { it.toURI().toURL() }.toArray(new URL[0])
+        ClassLoader classpathLoader = new URLClassLoader(classpathUrls, (java.lang.ClassLoader)null)
+
+        // Generate the metadata for the Reflections library.
+        new org.reflections.Reflections(
+            new org.reflections.util.ConfigurationBuilder()
+                .forPackage("frc.robot", projectLoader)
+                .forPackage("com.nrg948", classpathLoader)
+                .setScanners(
+                    org.reflections.scanners.Scanners.FieldsAnnotated,
+                    org.reflections.scanners.Scanners.MethodsAnnotated,
+                    org.reflections.scanners.Scanners.SubTypes,
+                    org.reflections.scanners.Scanners.TypesAnnotated))
+            .save("${project.sourceSets.main.output.classesDirs.asPath}/META-INF/reflections/${project.archivesBaseName}-reflections.xml")
+    }
+}
+
+// Generate the NRG Common Library metadata when the robot code is built.
+jar.dependsOn generateReflectionsMetadata

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,7 +4,7 @@
 
 package frc.robot;
 
-import com.nrg948.preferences.RobotPreferences;
+import com.nrg948.Common;
 
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -27,8 +27,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
-    RobotPreferences.init("frc.robot");
-    
+    // Initialize the NRG Common Library before creating the RobotContainer so that
+    // it is initialized and ready for use by the subsystems.
+    Common.init("frc.robot");
+       
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();


### PR DESCRIPTION
This PR adds a custom build task to pre-generate the annotation metadata for the NRG Common Library. This should help to reduce the startup time of the robot code.

Requires NRG948/nrgcommon#27 to be merged first.
