### PR TITLE
Make the AprilTagSubsystem optional

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -174,7 +174,11 @@ public class RobotContainer {
     RobotPreferences.addShuffleBoardTab();
 
     subsystems.drivetrain.addShuffleboardTab();
-    subsystems.aprilTag.addShuffleboardTab();
+
+    if (subsystems.aprilTag.isPresent()) {
+      subsystems.aprilTag.get().addShuffleboardTab();
+    }
+
     if (subsystems.noteVision.isPresent()) {
       subsystems.noteVision.get().addShuffleboardTab();
     }

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -32,8 +32,12 @@ public final class DriveCommands {
   /** Returns a Command that drives to amp delivery position. */
   public static Command driveToAmp(Subsystems subsystems) {
 
+    if (subsystems.aprilTag.isEmpty()) {
+      return Commands.none(); // TODO blink LEDS red to tell driver we can't see the target
+    }
+
     var drivetrain = subsystems.drivetrain;
-    var aprilTag = subsystems.aprilTag;
+    var aprilTag = subsystems.aprilTag.get();
 
     var targetID = AprilTagSubsystem.getAmpAprilTagID();
     var targetOptional = aprilTag.getTarget(targetID);

--- a/src/main/java/frc/robot/commands/DriveUsingController.java
+++ b/src/main/java/frc/robot/commands/DriveUsingController.java
@@ -48,7 +48,7 @@ public class DriveUsingController extends Command {
       new RobotPreferences.DoubleValue("NoteVision", "kD", 0.0);
 
   private final SwerveSubsystem drivetrain;
-  private final AprilTagSubsystem aprilTag;
+  private final Optional<AprilTagSubsystem> aprilTag;
   private final Optional<NoteVisionSubsystem> noteVision;
   private final CommandXboxController xboxController;
   private ProfiledPIDController profiledPIDController;
@@ -91,8 +91,9 @@ public class DriveUsingController extends Command {
 
     Optional<PhotonTrackedTarget> optionalTagTarget = Optional.empty();
     Optional<PhotonTrackedTarget> optionalNoteTarget = Optional.empty();
-    if (xboxController.getHID().getRightStickButton()) {
-      optionalTagTarget = aprilTag.getTarget(AprilTagSubsystem.getSpeakerCenterAprilTagID());
+
+    if (xboxController.getHID().getRightStickButton() && aprilTag.isPresent()) {
+      optionalTagTarget = aprilTag.get().getTarget(AprilTagSubsystem.getSpeakerCenterAprilTagID());
     } else if (xboxController.getHID().getXButton()
         && noteVision.isPresent()
         && noteVision.get().hasTargets()) { // Nonpermanent X binding

--- a/src/main/java/frc/robot/commands/SetShooterContinous.java
+++ b/src/main/java/frc/robot/commands/SetShooterContinous.java
@@ -11,6 +11,7 @@ import frc.robot.subsystems.AprilTagSubsystem;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 import frc.robot.subsystems.Subsystems;
+import java.util.Optional;
 
 /**
  * A command that continously sets arm angle and shooter rpms based on speaker april tag.
@@ -20,7 +21,7 @@ import frc.robot.subsystems.Subsystems;
 public class SetShooterContinous extends Command {
   private final ArmSubsystem arm;
   private final ShooterSubsystem shooter;
-  private final AprilTagSubsystem aprilTag;
+  private final Optional<AprilTagSubsystem> aprilTag;
 
   private record ShooterParams(double distance, double armAngleDegrees, int rpm) {}
 
@@ -48,15 +49,23 @@ public class SetShooterContinous extends Command {
 
   @Override
   public void execute() {
+    if (aprilTag.isEmpty()) {
+      return;
+    }
+
     int tagId = AprilTagSubsystem.getSpeakerCenterAprilTagID();
-    double distance = aprilTag.getDistanceToTarget(tagId);
+    double distance = aprilTag.get().getDistanceToTarget(tagId);
+
     if (distance == 0) { // if target is not detected
       return;
     }
+
     if (distance > shooterParams[shooterParams.length - 1].distance) {
       return; // if target is greater than farthest point (last index)
     }
+
     ShooterParams computedShooterParams = computeShooterParams(distance);
+
     arm.setGoalAngleContinous(Math.toRadians(computedShooterParams.armAngleDegrees));
     shooter.setGoalRPM(computedShooterParams.rpm);
   }

--- a/src/main/java/frc/robot/subsystems/AprilTagSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AprilTagSubsystem.java
@@ -48,6 +48,10 @@ public class AprilTagSubsystem extends PhotonVisionSubsystemBase {
       new EstimatedRobotPose(NO_APRILTAG, 0, List.of(), PoseStrategy.LOWEST_AMBIGUITY);
 
   @RobotPreferencesValue
+  public static final RobotPreferences.BooleanValue ENABLED =
+      new RobotPreferences.BooleanValue("AprilTag", "Enabled", false);
+
+  @RobotPreferencesValue
   public static final RobotPreferences.BooleanValue enableTab =
       new RobotPreferences.BooleanValue("AprilTag", "Enable Tab", false);
 


### PR DESCRIPTION
Makes the AprilTagSubsystem optional. A preference value control whether it is created during robot startup. It is disabled by default.