### PR TITLE
Avoid allocating small objects in high frequency functions

### DIFF
--- a/src/main/java/frc/robot/drive/SwerveModule.java
+++ b/src/main/java/frc/robot/drive/SwerveModule.java
@@ -66,9 +66,9 @@ public class SwerveModule {
   private double steeringVoltage;
 
   // The current supplied state updated by the periodic method.
-  private SwerveModuleState state;
-  private SwerveModulePosition position;
-  private SwerveModuleVelocities velocities;
+  private final SwerveModuleState state = new SwerveModuleState();
+  private final SwerveModulePosition position = new SwerveModulePosition();
+  private final SwerveModuleVelocities velocities = new SwerveModuleVelocities();
 
   private final DoubleLogEntry driveSpeedLog;
   private final DoubleLogEntry positionLog;
@@ -191,9 +191,14 @@ public class SwerveModule {
     double wheelAngleVelocity = wheelAngleVelocitySupplier.getAsDouble();
     double position = positionSupplier.getAsDouble();
 
-    this.position = new SwerveModulePosition(position, wheelAngle);
-    this.state = new SwerveModuleState(velocity, wheelAngle);
-    this.velocities = new SwerveModuleVelocities(velocity, wheelAngleVelocity);
+    this.position.distanceMeters = position;
+    this.position.angle = wheelAngle;
+
+    this.state.speedMetersPerSecond = velocity;
+    this.state.angle = wheelAngle;
+
+    this.velocities.driveVelocity = velocity;
+    this.velocities.steeringVelocity = wheelAngleVelocity;
 
     driveSpeedLog.append(velocity);
     positionLog.append(position);

--- a/src/main/java/frc/robot/subsystems/AprilTagSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AprilTagSubsystem.java
@@ -52,7 +52,7 @@ public class AprilTagSubsystem extends PhotonVisionSubsystemBase {
       new RobotPreferences.BooleanValue("AprilTag", "Enabled", false);
 
   @RobotPreferencesValue
-  public static final RobotPreferences.BooleanValue enableTab =
+  public static final RobotPreferences.BooleanValue ENABLE_TAB =
       new RobotPreferences.BooleanValue("AprilTag", "Enable Tab", false);
 
   private final PhotonPoseEstimator estimator;
@@ -198,15 +198,18 @@ public class AprilTagSubsystem extends PhotonVisionSubsystemBase {
   @Override
   public void periodic() {
     super.periodic();
+
     estimator.update(getLatestResult());
 
-    selectedAprilTag = aprilTagIdChooser.getSelected().intValue();
-    selectedAprilTagPose = getAprilTagPose(selectedAprilTag);
+    if (ENABLE_TAB.getValue()) {
+      selectedAprilTag = aprilTagIdChooser.getSelected().intValue();
+      selectedAprilTagPose = getAprilTagPose(selectedAprilTag);
+    }
   }
 
   /** Adds a tab for April Tag in Shuffleboard. */
   public void addShuffleboardTab() {
-    if (!enableTab.getValue()) {
+    if (!ENABLE_TAB.getValue()) {
       return;
     }
 

--- a/src/main/java/frc/robot/util/SwerveModuleVelocities.java
+++ b/src/main/java/frc/robot/util/SwerveModuleVelocities.java
@@ -9,10 +9,15 @@ package frc.robot.util;
 /** Represents swerve module velocities. */
 public class SwerveModuleVelocities {
   /** The translational velocity of the wheel in m/s. */
-  public final double driveVelocity;
+  public double driveVelocity;
 
   /** The rotational velocity of the wheel in rad/s */
-  public final double steeringVelocity;
+  public double steeringVelocity;
+
+  /** Creates a new SwerveModuleVelocities. */
+  public SwerveModuleVelocities() {
+    this(0, 0);
+  }
 
   /**
    * Creates a new SwerveModuleVelocities.


### PR DESCRIPTION
This PR contains the following changes:

1. Reuse objects for state, position and velocity reporting in `SwerveModule`.
2. Avoid allocating `Rotation2d` objects to perform simple math on angles in `SwerveModule` and `DriveUsingController`. (NOTE: Our usage of [`Rotation2d.plus(Rotation2d)`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/math/geometry/Rotation2d.html#plus(edu.wpi.first.math.geometry.Rotation2d)) produced an angle between -π..+π and I tried to preserve this behavior by using [`MathUtil.angleModulus(double)`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/math/MathUtil.html#angleModulus(double)))
3. Avoid the periodic call to update the selected AprilTag if the `AprilTagSubsystem`'s Shuffleboard tab is not enabled. (This isn't really allocating small objects but it's unnecessary work in `periodic`.)